### PR TITLE
qttools 6.7.3: x11_gui_rebuilds

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/qtbase-feedstock/pr7/b35796f
+  - https://staging.continuum.io/prefect/fs/qtbase-feedstock/pr7/fe77d94

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/mesalib-feedstock/pr1/e7fea05
+  - https://staging.continuum.io/prefect/fs/qtbase-feedstock/pr7/b35796f

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/mesalib-feedstock/pr1/e7fea05

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/qtbase-feedstock/pr7/01c13ff
-  - https://staging.continuum.io/prefect/fs/qtsvg-feedstock/pr3/ca0b71a
-  - https://staging.continuum.io/prefect/fs/qtshadertools-feedstock/pr3/88c9288
-  - https://staging.continuum.io/prefect/fs/qtdeclarative-feedstock/pr3/80cb92c

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,6 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/qtbase-feedstock/pr7/fe77d94
+channels:
+  - https://staging.continuum.io/prefect/fs/qtbase-feedstock/pr7/1550c51
+  - https://staging.continuum.io/prefect/fs/qtsvg-feedstock/pr3/db5fd53
+  - https://staging.continuum.io/prefect/fs/qtshadertools-feedstock/pr3/a67f387
+  - https://staging.continuum.io/prefect/fs/qtdeclarative-feedstock/pr3/5776ef6

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,5 @@
 channels:
-channels:
-  - https://staging.continuum.io/prefect/fs/qtbase-feedstock/pr7/1550c51
-  - https://staging.continuum.io/prefect/fs/qtsvg-feedstock/pr3/db5fd53
-  - https://staging.continuum.io/prefect/fs/qtshadertools-feedstock/pr3/a67f387
-  - https://staging.continuum.io/prefect/fs/qtdeclarative-feedstock/pr3/5776ef6
+  - https://staging.continuum.io/prefect/fs/qtbase-feedstock/pr7/01c13ff
+  - https://staging.continuum.io/prefect/fs/qtsvg-feedstock/pr3/ca0b71a
+  - https://staging.continuum.io/prefect/fs/qtshadertools-feedstock/pr3/88c9288
+  - https://staging.continuum.io/prefect/fs/qtdeclarative-feedstock/pr3/80cb92c

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,7 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - pkg-config  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,28 +20,14 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - {{ cdt('libdrm-devel') }}               # [linux]
-    - {{ cdt('libglvnd-glx') }}               # [linux and not x86_64]
-    - {{ cdt('libglvnd-egl') }}               # [linux and not x86_64]
-    - {{ cdt('libice-devel') }}               # [linux]
-    - {{ cdt('libsm-devel') }}                # [linux]
-    - {{ cdt('libx11-devel') }}               # [linux]
-    - {{ cdt('libxau-devel') }}               # [linux]
-    - {{ cdt('mesa-libgl-devel') }}           # [linux]
-    - {{ cdt('mesa-libgbm') }}                # [linux]
-    - {{ cdt('mesa-libegl-devel') }}          # [linux]
-    - {{ cdt('mesa-dri-drivers') }}           # [linux]
-    - {{ cdt('xcb-util-devel') }}             # [linux]
-    - {{ cdt('xcb-util-image-devel') }}       # [linux]
-    - {{ cdt('xcb-util-keysyms-devel') }}     # [linux]
-    - {{ cdt('xcb-util-renderutil-devel') }}  # [linux]
-    - {{ cdt('xcb-util-wm-devel') }}          # [linux]
-    - {{ cdt('xorg-x11-proto-devel') }}       # [linux]
-    - {{ cdt('libselinux') }}                 # [linux]
-    - {{ cdt('libxext') }}                    # [linux]
-    - {{ cdt('libxdamage') }}                 # [linux]
-    - {{ cdt('libxfixes') }}                  # [linux]
-    - {{ cdt('libxxf86vm') }}                 # [linux]
+    # TODO: map CDT libdrm-devel to new X11 package
+    # - { cdt('libdrm-devel') }
+    # TODO: map CDT mesa-libgbm to new X11 package
+    # - { cdt('mesa-libgbm') }
+    # TODO: map CDT mesa-libegl-devel to new X11 package
+    # - { cdt('mesa-libegl-devel') }
+    # TODO: map CDT libselinux to new X11 package
+    # - { cdt('libselinux') }
     - pkg-config  # [unix]
     - bison       # [linux]
     - flex        # [linux]
@@ -59,6 +45,24 @@ requirements:
     - qtdeclarative {{ version }}
     - zstd
 
+    - libglx
+    - libegl
+    - xorg-libice
+    - xorg-libsm
+    - xorg-libx11
+    - xorg-libxau
+    - libgl-devel
+    - mesa-dri-drivers
+    - xcb-util
+    - xcb-util-image
+    - xcb-util-keysyms
+    - xcb-util-renderutil
+    - xcb-util-wm
+    - xorg-xproto
+    - xorg-libxext
+    - xorg-libxdamage
+    - xorg-libxfixes
+    - xorg-libxxf86vm
   run_constrained:
     - qt-main >={{ version }},<7
     - qt >={{ version }},<7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,12 +33,9 @@ requirements:
     - perl
 
   host:
-    - qtbase {{ version }}
+    - qtbase-devel {{ version }}
     - qtdeclarative {{ version }}
-    - zstd
-    # X11 dependencies
-    - libgl-devel  # [linux]
-    - libegl-devel  # [linux]
+    - zstd {{ zstd }}
   run_constrained:
     - qt-main >={{ version }},<7
     - qt >={{ version }},<7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,11 +37,7 @@ requirements:
     - qtdeclarative {{ version }}
     - zstd
     # X11 dependencies
-    - libgl  # [linux]
     - libgl-devel  # [linux]
-    - mesa-libgl-devel  # [linux]
-    - mesalib  # [linux]
-    - libegl  # [linux]
     - libegl-devel  # [linux]
   run_constrained:
     - qt-main >={{ version }},<7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,13 +6,13 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://download.qt.io/official_releases/qt/{{ version.rpartition('.')[0] }}/{{ version }}/submodules/{{ name }}-everywhere-src-{{ version }}.tar.xz
+  - url: https://download.qt.io/archive/qt/{{ version.rpartition('.')[0] }}/{{ version }}/submodules/{{ name }}-everywhere-src-{{ version }}.tar.xz
     sha256: f03bb7df619cd9ac9dba110e30b7bcab5dd88eb8bdc9cc752563b4367233203f
     folder: {{ name }}
 
 build:
-  number: 0
-  skip: True  # [ppc64le or s390x or (osx and x86_64)]
+  number: 1
+  skip: True  # [osx and x86_64]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
 
@@ -20,14 +20,6 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    # TODO: map CDT libdrm-devel to new X11 package
-    # - { cdt('libdrm-devel') }
-    # TODO: map CDT mesa-libgbm to new X11 package
-    # - { cdt('mesa-libgbm') }
-    # TODO: map CDT mesa-libegl-devel to new X11 package
-    # - { cdt('mesa-libegl-devel') }
-    # TODO: map CDT libselinux to new X11 package
-    # - { cdt('libselinux') }
     - pkg-config  # [unix]
     - bison       # [linux]
     - flex        # [linux]
@@ -44,25 +36,13 @@ requirements:
     - qtbase {{ version }}
     - qtdeclarative {{ version }}
     - zstd
-
-    - libglx
-    - libegl
-    - xorg-libice
-    - xorg-libsm
-    - xorg-libx11
-    - xorg-libxau
-    - libgl-devel
-    - mesa-dri-drivers
-    - xcb-util
-    - xcb-util-image
-    - xcb-util-keysyms
-    - xcb-util-renderutil
-    - xcb-util-wm
-    - xorg-xproto
-    - xorg-libxext
-    - xorg-libxdamage
-    - xorg-libxfixes
-    - xorg-libxxf86vm
+    # X11 dependencies
+    - libgl  # [linux]
+    - libgl-devel  # [linux]
+    - mesa-libgl-devel  # [linux]
+    - mesalib  # [linux]
+    - libegl  # [linux]
+    - libegl-devel  # [linux]
   run_constrained:
     - qt-main >={{ version }},<7
     - qt >={{ version }},<7


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7776](https://anaconda.atlassian.net/browse/PKG-7776)
- [Upstream repository]()

### Explanation of changes:

-

### Notes:

- Automated migration/rebuild for group x11_gui_rebuilds.


[PKG-7776]: https://anaconda.atlassian.net/browse/PKG-7776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ