### PR TITLE
Update to v6.9.2

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,8 +2,8 @@
 c_stdlib_version:  # [not linux]
   - 12.0           # [osx]
   - 2022.12        # [win]
-OSX_SDK_VER:
-  - 13.3
+OSX_SDK_VER:       # [osx]
+  - 13.3           # [osx]
 
 # https://doc.qt.io/qt-6/windows.html
 c_compiler:    # [win]
@@ -18,11 +18,7 @@ c_compiler_version:    # [osx]
 cxx_compiler_version:  # [osx]
   - 17                 # [osx]
 
-# Need at least a 12.0 host or else tests will fail.
-extra_labels_for_os:
-  osx-arm64: [ventura]
-
 # Have to leave this for now or else the overlinking checks fail when we revert back to the aggregate CBC and use the
-# 11.1 sysroot.
+# 12.1 sysroot.
 CONDA_BUILD_SYSROOT:
   - /Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk  # [osx and arm64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "qttools" %}
-{% set version = "6.9.1" %}
+{% set version = "6.9.2" %}
 
 package:
   name: {{ name }}
@@ -7,12 +7,11 @@ package:
 
 source:
   - url: https://download.qt.io/official_releases/qt/{{ version.rpartition('.')[0] }}/{{ version }}/submodules/{{ name }}-everywhere-src-{{ version }}.tar.xz
-    sha256: 90c4a562f4ccfd043fd99f34c600853e0b5ba9babc6ec616c0f306f2ce3f4b4c
+    sha256: d8b7f7e8e970cc0b975205fd6d5832ea917ef3e751df69b97439c1cddd67a489
     folder: {{ name }}
 
 build:
   number: 0
-  skip: True  # [osx and x86_64]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
 


### PR DESCRIPTION
qttools 6.9.2

**Destination channel:** defaults

### Links

- [PKG-9667](https://anaconda.atlassian.net/browse/PKG-9667)
- [Upstream repository](https://github.com/qt/qttools/tree/v6.9.2)
- [Upstream changelog/diff](https://github.com/qt/qttools/compare/v6.9.1...v6.9.2)

[PKG-9667]: https://anaconda.atlassian.net/browse/PKG-9667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ