### PR TITLE
Rebuild against qtbase with libjpeg-turbo

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -20,3 +20,6 @@ cxx_compiler_version:  # [osx]
 
 CONDA_BUILD_SYSROOT:
   - /Library/Developer/CommandLineTools/SDKs/MacOSX14.5.sdk  # [osx]
+
+libvulkan:
+  - 1.4.313.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     folder: {{ name }}
 
 build:
-  number: 0
+  number: 1
   # https://doc.qt.io/qt-6/qt-releases.html#binary-compatibility
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}


### PR DESCRIPTION
qttools 6.11.0

**Destination channel:**  defaults

### Links

- [PKG-15505](https://anaconda.atlassian.net/browse/PKG-15505) 
- [Upstream repository](https://github.com/qt/qttools/tree/v6.11.0)

### Explanation of changes:
- Rebuild against qtbase with libjpeg-turbo


[PKG-15505]: https://anaconda.atlassian.net/browse/PKG-15505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ